### PR TITLE
Reuse systems input for flake-utils

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     flake-utils.url = "github:numtide/flake-utils";
+    flake-utils.inputs.systems.follows = "systems";
     systems.url = "github:nix-systems/default";
   };
 


### PR DESCRIPTION
This change should make `flake-utils` use the same `systems` input as root. This prevents a duplicate input `systems_2` from appearing in `flake.lock`.